### PR TITLE
Add support for passing event params for filtering events

### DIFF
--- a/src/mailgun/mail.clj
+++ b/src/mailgun/mail.clj
@@ -74,6 +74,10 @@
       (client/post url content))
     (throw (Exception. "Invalid/Incomplete message-content"))))
 
+(defn gen-event-body
+  [key params]
+  (merge (gen-auth key) {:query-params params}))
+
 (defn get-stored-events
   "Returns stored events
 
@@ -89,9 +93,8 @@
    (get-stored-events auth {}))
   ([{:keys [domain key]} query-params]
    (let [url (gen-url "/events" domain)
-         auth (gen-auth key)
-         params (merge auth {:query-params query-params})]
-     (util/json-to-clj (client/get url params)))))
+         content (gen-event-body key query-params)]
+     (util/json-to-clj (client/get url content)))))
 
 (defn get-stored-message
   "Returns a stored message given the message-key"

--- a/src/mailgun/mail.clj
+++ b/src/mailgun/mail.clj
@@ -75,11 +75,23 @@
     (throw (Exception. "Invalid/Incomplete message-content"))))
 
 (defn get-stored-events
-  "Returns stored events"
-  [{:keys [domain key]}]
-  (let [url (gen-url "/events" domain)
-        auth (gen-auth key)]
-    (util/json-to-clj (client/get url auth))))
+  "Returns stored events
+
+  This is a multi-arity function. Pass authentication credentials to retrieve
+  all stored events (100 by default) for your domain, or pass a set of query
+  parameters to further refine your event list.
+
+  A sample request with query params would look like
+  (gets-stored-events {:key \"key-3ax6xnjp29jd6fds4gc373sgvjxteol1\" :domain \"bar.com\"}
+                      {:limit 10
+                       :event \"opened\"})"
+  ([auth]
+   (get-stored-events auth {}))
+  ([{:keys [domain key]} query-params]
+   (let [url (gen-url "/events" domain)
+         auth (gen-auth key)
+         params (merge auth {:query-params query-params})]
+     (util/json-to-clj (client/get url params)))))
 
 (defn get-stored-message
   "Returns a stored message given the message-key"

--- a/test/mailgun/mail_test.clj
+++ b/test/mailgun/mail_test.clj
@@ -29,6 +29,16 @@
                           :attachment ["attachment1" "attachment2"]}]
       (is (= multi-part-map (mail/gen-body request-params))))))
 
+(deftest test-gen-event-body
+  (testing "gen-event-body to see if return a valid query"
+    (let [key "key-3ax6xnjp29jd6fds4gc373sgvjxteol1"
+          params {:limit 10 :event "opened"}
+          expected {:basic-auth ["api" key]
+                    :query-params {:limit 10
+                                   :event "opened"}}
+          result (mail/gen-event-body key params)]
+      (is (= expected result)))))
+
 (deftest parse-message-body
   (testing "parsing the mesage body gives valid fields"
     (let [sample-body-reponse {"X-Envelope-From" "<test@foo.com>"


### PR DESCRIPTION
This PR adds support for passing parameters to the `get-stored-events` function, to perform server-side filtering.

If there is anything else you'd like me to add to get this PR merged just let me know.